### PR TITLE
Fix theme provider

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,18 +1,20 @@
 import './global.scss'
 import { AppProps } from 'next/app'
-import { ThemeProvider } from '@mui/material'
-import { darkTheme } from './_libs/theme-provider'
+import { StyledEngineProvider, Experimental_CssVarsProvider } from '@mui/material/styles'
+import { theme } from './_libs/theme-provider'
 import AppHeader from './_components/AppHeader/AppHeader'
 
 /// https://nextjs.org/docs/advanced-features/custom-app
 export default function _App({ Component, pageProps }: AppProps) {
   return (
-    <main style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-      <ThemeProvider theme={darkTheme}>
-        <AppHeader />
-        <Component {...pageProps} />
-        {/* Footer? - use footer html tag*/}
-      </ThemeProvider>
-    </main>
+    <StyledEngineProvider injectFirst>
+      <Experimental_CssVarsProvider defaultMode="dark" theme={theme}>
+        <main style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+          <AppHeader />
+          <Component {...pageProps} />
+          {/* Footer? - use footer html tag*/}
+        </main>
+      </Experimental_CssVarsProvider>
+    </StyledEngineProvider>
   )
 }

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,6 +1,5 @@
 import { Html, Head, Main, NextScript } from 'next/document'
-import { StyledEngineProvider, getInitColorSchemeScript } from '@mui/material/styles'
-import { Experimental_CssVarsProvider } from '@mui/material/styles'
+import { getInitColorSchemeScript } from '@mui/material/styles'
 
 /// https://nextjs.org/docs/advanced-features/custom-document
 export default function _Document() {
@@ -8,12 +7,8 @@ export default function _Document() {
     <Html lang="en">
       <Head />
       <body>
-        <StyledEngineProvider injectFirst>
-          <Experimental_CssVarsProvider>
-            {getInitColorSchemeScript()}
-            <Main />
-          </Experimental_CssVarsProvider>
-        </StyledEngineProvider>
+        {getInitColorSchemeScript()}
+        <Main />
         <NextScript />
       </body>
     </Html>

--- a/pages/_libs/theme-provider.ts
+++ b/pages/_libs/theme-provider.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-unused-vars */
 import { IBM_Plex_Mono, Text_Me_One } from '@next/font/google'
-import { createTheme, responsiveFontSizes, Theme } from '@mui/material'
+import { responsiveFontSizes, experimental_extendTheme as extendTheme } from '@mui/material'
+import type {} from '@mui/material/themeCssVarsAugmentation' // extend the typings so that `theme.vars` is accessible.
 
 const textMeOne = Text_Me_One({ weight: '400', subsets: ['latin'] })
 const IBMPlexMono = IBM_Plex_Mono({ weight: '400', subsets: ['latin'] })
@@ -11,22 +12,25 @@ declare module '@mui/material/Button' {
   }
 }
 
-export const darkTheme: Theme = responsiveFontSizes(
-  createTheme({
+export const theme = responsiveFontSizes(
+  extendTheme({
     typography: {
       fontFamily: `${textMeOne.style.fontFamily}`,
     },
-    palette: {
-      mode: 'dark',
-      secondary: {
-        main: '#ff8080',
+    colorSchemes: {
+      dark: {
+        palette: {
+          secondary: {
+            main: '#ff8080',
+          },
+          background: {
+            default: '#191c20',
+            paper: '#25292e',
+          },
+          divider: 'rgba(255,255,255,0.78)',
+          contrastThreshold: 4.5,
+        },
       },
-      background: {
-        default: '#191c20',
-        paper: '#25292e',
-      },
-      divider: 'rgba(255,255,255,0.78)',
-      contrastThreshold: 4.5,
     },
     components: {
       MuiIconButton: {
@@ -62,4 +66,4 @@ export const darkTheme: Theme = responsiveFontSizes(
       },
     },
   })
-)
+) as ReturnType<typeof extendTheme>

--- a/pages/home/FetchContainer/_components/JSONMirror.tsx
+++ b/pages/home/FetchContainer/_components/JSONMirror.tsx
@@ -1,27 +1,29 @@
 import CodeMirror from '@uiw/react-codemirror'
+import { useTheme } from '@mui/material/styles'
 import styles from '../FetchSection.module.scss'
 import { createTheme } from '@uiw/codemirror-themes'
 import { json } from '@codemirror/lang-json'
 import { tags } from '@lezer/highlight'
 
 const extensions = [json()]
-const holocronTheme = createTheme({
-  theme: 'dark',
-  settings: {
-    background: '#141414',
-    foreground: '#ff8080',
-    selection: '#282828',
-    caret: '#141414',
-  },
-  styles: [
-    { tag: tags.string, color: '#80ffff' },
-    { tag: tags.bracket, color: '#8088ff' },
-    { tag: tags.squareBracket, color: '#ff80ff' },
-  ],
-})
 
 /// CodeMirror library with configuration and styling
 export default function JSONMirror({ data }: { data: string }) {
+  const theme = useTheme()
+  const holocronTheme = createTheme({
+    theme: 'dark',
+    settings: {
+      background: '#141414',
+      foreground: theme.vars.palette.secondary.main, // theme.vars typings is extended in `theme-provider.ts`
+      selection: '#282828',
+      caret: '#141414',
+    },
+    styles: [
+      { tag: tags.string, color: '#80ffff' },
+      { tag: tags.bracket, color: '#8088ff' },
+      { tag: tags.squareBracket, color: '#ff80ff' },
+    ],
+  })
   return (
     <CodeMirror
       readOnly


### PR DESCRIPTION
From my understanding, your app supports only dark mode so this is what I did:

- Remove ThemeProvider from the `_document.tsx`. The ThemeProvider should be in `_app.tsx`.
- Use Experimental_CssVarsProvider instead of ThemeProvider to generate CSS variables and set the `defaultMode` to `dark` (clear your local storage first).
- Replace `createTheme` with `extendTheme` for using with CssVarsProvider according to the [docs](https://mui.com/material-ui/experimental-api/css-theme-variables/customization/).
- use `useTheme` in the JSONMirror component (You could also use plain string `foreground: 'var(--joy-palette-secondary-main)'`

<img width="1440" alt="Screen Shot 2566-01-03 at 15 54 31" src="https://user-images.githubusercontent.com/18292247/210325642-19484f25-fdf1-4189-a644-07e0e6af5333.png">
